### PR TITLE
Add support for customer_email, fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
   },
   "require": {
     "php": "^7",
-    "php-http/guzzle6-adapter": "^2.0",
     "omnipay/common": "^3.0",
     "stripe/stripe-php": "^7.75"
   },

--- a/src/Messages/AbstractCheckoutRequest.php
+++ b/src/Messages/AbstractCheckoutRequest.php
@@ -31,9 +31,9 @@ abstract class AbstractCheckoutRequest extends AbstractRequest
      *
      * @return string
      */
-    public function getCustomerEmail(): string
+    public function getCustomerEmail()
     {
-        return $this->getParameter('customerEmail') ?? '';
+        return $this->getParameter('customerEmail');
     }
 
     /**

--- a/src/Messages/AbstractCheckoutRequest.php
+++ b/src/Messages/AbstractCheckoutRequest.php
@@ -29,7 +29,7 @@ abstract class AbstractCheckoutRequest extends AbstractRequest
     /**
      * Get the customer email.
      *
-     * @return string
+     * @return string|null
      */
     public function getCustomerEmail()
     {

--- a/src/Messages/AbstractCheckoutRequest.php
+++ b/src/Messages/AbstractCheckoutRequest.php
@@ -33,7 +33,7 @@ abstract class AbstractCheckoutRequest extends AbstractRequest
      */
     public function getCustomerEmail(): string
     {
-        return $this->getParameter('customerEmail');
+        return $this->getParameter('customerEmail') ?? '';
     }
 
     /**

--- a/src/Messages/AbstractCheckoutRequest.php
+++ b/src/Messages/AbstractCheckoutRequest.php
@@ -25,4 +25,24 @@ abstract class AbstractCheckoutRequest extends AbstractRequest
     {
         return $this->setParameter('apiKey', $value);
     }
+
+    /**
+     * Get the customer email.
+     *
+     * @return string
+     */
+    public function getCustomerEmail(): string
+    {
+        return $this->getParameter('customerEmail');
+    }
+
+    /**
+     * Set the customer email.
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setCustomerEmail($value): AbstractRequest
+    {
+        return $this->setParameter('customerEmail', $value);
+    }
 }

--- a/src/Messages/PurchaseRequest.php
+++ b/src/Messages/PurchaseRequest.php
@@ -31,6 +31,7 @@ class PurchaseRequest extends AbstractCheckoutRequest
         $session = \Stripe\Checkout\Session::create(
             [
                 'client_reference_id' => $this->getTransactionId(),
+                'customer_email' => $this->getCustomerEmail(),
                 'payment_method_types' => ['card'],
                 'payment_intent_data' => [
                     'description' => $this->getDescription(),


### PR DESCRIPTION
This PR allows to pass the `customer_email` field to Stripe. This pre-populates the email field in the order form.

It also removes the unused `php-http/guzzle6-adapter` dependency. This dependency creates a conflict when the package is installed in a project that requires Guzzle v7.